### PR TITLE
cross-origin-requests (CORS) with credentials allowed for dev

### DIFF
--- a/settings/base.py
+++ b/settings/base.py
@@ -41,7 +41,7 @@ INSTALLED_APPS = [
     # framework for creating api
     'rest_framework',
 
-    # Adds cross-origin headers to http request
+    # Adds cross-origin headers to http request in development
     'corsheaders',
 
     # Main project app
@@ -66,8 +66,6 @@ AUTHENTICATION_BACKENDS = (
 # Crucial for 'lazysignup' to recognize anonymous user in subsequent requests
 # NOTE: the session cookie won't be sent to the user anyway after Server Internal Error
 SESSION_SAVE_EVERY_REQUEST = True
-
-CORS_ORIGIN_ALLOW_ALL = True
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/settings/dev/base.py
+++ b/settings/dev/base.py
@@ -8,3 +8,8 @@ DATABASES = {
         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
     }
 }
+
+# This allows the regular pp-client scripts to access API in development
+# Chrome extension is allowed access as it explicitly defines allowed resource domains in manifest.json permissions
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOW_CREDENTIALS = True

--- a/settings/prod_heroku.py
+++ b/settings/prod_heroku.py
@@ -22,3 +22,6 @@ STATICFILES_DIRS = [
 # Simplified static file serving.
 # https://warehouse.python.org/project/whitenoise/
 # STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+
+CORS_ORIGIN_ALLOW_ALL = False
+CORS_ALLOW_CREDENTIALS = False


### PR DESCRIPTION
**Summary**
1) for **development**: allow CORS with session cookies (until now allowed only without credentials)
2) for **production**: do not allow CORS in production (Chrome-extension `manifest.json` `permissions` should make it possible to access API but it remains to be checked)
 

(1) allows to use pure pp-client (not the browser extension client) to access API with session cookies.