### PR TITLE
Remove unnecessary SESSION_SAVE_EVERY_REQUEST

### DIFF
--- a/settings/base.py
+++ b/settings/base.py
@@ -71,11 +71,6 @@ AUTHENTICATION_BACKENDS = (
     'lazysignup.backends.LazySignupBackend',
 )
 
-# Overwrite default Django behaviour and sends a session cookie to every request (also unlogged ones)
-# Crucial for 'lazysignup' to recognize anonymous user in subsequent requests
-# NOTE: the session cookie won't be sent to the user anyway after Server Internal Error
-SESSION_SAVE_EVERY_REQUEST = True
-
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',


### PR DESCRIPTION
Session cookie is created for every visitor anyway, but the session
record in the database does not need to be updated with every
request, which is huge performance threat.