### PR TITLE
Modify serialization of null annotation range

### DIFF
--- a/apps/annotation/serializers.py
+++ b/apps/annotation/serializers.py
@@ -39,7 +39,7 @@ class ObjectField(serializers.Field):
 
     def to_representation(self, value):
         if value is None or value == "":
-            return {}
+            return None
         if self.json_internal_type:
             return json.loads(value)
         return value


### PR DESCRIPTION
The null annotation range was serialized as '{}' (empty JSON).
Now a null range is serialized as null, and a correct JSON string is just passed on as before.

This allows to intuitively differentiate between the provided and unprovided range value on the client side (rather than counting an empty JSON keys)