### PR TITLE
Fix annotation-sensitive filtering, request content-type & pagination

### DIFF
--- a/apps/annotation/filters.py
+++ b/apps/annotation/filters.py
@@ -1,7 +1,6 @@
 import coreapi
 import coreschema
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework.filters import BaseFilterBackend
 
 from apps.annotation.utils import standardize_url_id
 
@@ -47,10 +46,9 @@ class StandardizedURLFilterBackend(GenericFilterBackend):
             )
         ]
 
-
 class StandardizedURLBodyFilterBackend(StandardizedURLFilterBackend):
     def get_filter_params(self, request):
-        return request.data
+        return request.data or {}
 
     def get_filter_schema_location(self):
         return 'form'

--- a/apps/annotation/pagination.py
+++ b/apps/annotation/pagination.py
@@ -1,0 +1,12 @@
+from rest_framework.pagination import BasePagination
+
+
+class ConstantLimitPagination(BasePagination):
+    """
+    A limit/offset based style. For example:
+
+    """
+    constant_limit = 100
+
+    def paginate_queryset(self, queryset, request, view=None):
+        return queryset[:self.constant_limit]

--- a/apps/annotation/tests/api/test_annotations_sensitive.py
+++ b/apps/annotation/tests/api/test_annotations_sensitive.py
@@ -1,0 +1,33 @@
+import json
+from django.test import TestCase
+from model_mommy import mommy
+from apps.annotation.tests.utils import create_test_user
+
+
+class AnnotationAPITest(TestCase):
+    base_url = "/api/annotations-sensitive"
+    maxDiff = None
+
+    def setUp(self):
+        self.user, self.password = create_test_user()
+        self.client.login(username=self.user, password=self.password)
+
+    def test_empty_returns_200(self):
+        response = self.client.post(
+            self.base_url,
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['content-type'], 'application/vnd.api+json')
+
+    def test_body_params_filtering(self):
+        mommy.make('annotation.Annotation', 1)
+        response = self.client.post(
+            self.base_url,
+            json.dumps({'url': 'not-existing.url'}),
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['content-type'], 'application/vnd.api+json')
+        response_content_data = json.loads(response.content.decode('utf8')).get('data')
+        self.assertEqual(len(response_content_data), 0)


### PR DESCRIPTION
**A bunch of fixes**
- Filtering didn't work due to JSONAPI parser
- Content-type is now in line with the request content
- Pagination remnants were removed since they were misleading for the `redux-json-api` client
- Additional tests were set up

First annotation view tests failed to detect problems related to request parsers.