### PR TITLE
Add annotationRequests endpoint and Mailgun configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ Done!
 ### Sending e-mails in development
 
 At this point any part of the application sending e-mail will fail
-(and its failure will be logged).
-Since there are no development API keys in Mailgun, private key should
-be manually set in the environment variable:
+(and its failure will be logged). This is not a problem unless
+you want to work on the e-mail sending part.
+Once you get hold
+of the private key, set the environment variable:
 
 `export MAILGUN_API_KEY=XXX`
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ Once previous step is complete, you just need to run the migrations
 
 Done!
 
+### Sending e-mails in development
+
+At this point any part of the application sending e-mail will fail
+(and its failure will be logged).
+Since there are no development API keys in Mailgun, private key should
+be manually set in the environment variable:
+
+`export MAILGUN_API_KEY=XXX`
+
 ### Special directories
 
 - `data/postgres` - data stored by postgres=databases

--- a/apps/annotation/mailgun.py
+++ b/apps/annotation/mailgun.py
@@ -1,6 +1,8 @@
 import requests
 from django.conf import settings
 
+class MailSendException(Exception):
+    pass
 
 def send_mail(to_addr, subject, text, sender,
               from_name='Przypis Powszechny',
@@ -15,6 +17,6 @@ def send_mail(to_addr, subject, text, sender,
               'text': text})
 
     if not (200 <= response.status_code < 300):
-        raise RuntimeError('Request to {} unexpected status {}. Response: \n {}'.format(
+        raise MailSendException('Request to {} unexpected status {}. Response: \n {}'.format(
             settings.MAILGUN_API_URL, response.status_code, response.content)
         )

--- a/apps/annotation/mailgun.py
+++ b/apps/annotation/mailgun.py
@@ -1,0 +1,20 @@
+import requests
+from django.conf import settings
+
+
+def send_mail(to_addr, subject, text, sender,
+              from_name='Przypis Powszechny',
+              to_name=None):
+    from_addr = '{}@{}'.format(sender, settings.PP_MAIL_DOMAIN)
+    response = requests.post(
+        settings.MAILGUN_API_URL,
+        auth=('api', settings.MAILGUN_API_KEY),
+        data={'from': '{} <{}>'.format(from_name, from_addr),
+              'to': '{} <{}>'.format(to_name, to_addr),
+              'subject': subject,
+              'text': text})
+
+    if not (200 <= response.status_code < 300):
+        raise RuntimeError('Request to {} unexpected status {}. Response: \n {}'.format(
+            settings.MAILGUN_API_URL, response.status_code, response.content)
+        )

--- a/apps/annotation/mailgun.py
+++ b/apps/annotation/mailgun.py
@@ -17,6 +17,8 @@ def send_mail(to_addr, subject, text, sender,
               'text': text})
 
     if not (200 <= response.status_code < 300):
-        raise MailSendException('Request to {} unexpected status {}. Response: \n {}'.format(
+        msg = 'Request to {} unexpected status {}. Response: \n {}'.format(
             settings.MAILGUN_API_URL, response.status_code, response.content)
-        )
+        if settings.DEBUG:
+            msg += '\nYou are in DEBUG mode -- make sure you have set MAILGUN_API_KEY environment variable in your local environment.'
+        raise MailSendException(msg)

--- a/apps/annotation/renderers.py
+++ b/apps/annotation/renderers.py
@@ -6,6 +6,8 @@ class JSONAPIRenderer(CamelCaseJSONRenderer):
     format = 'vnd.api+json'
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
+        # In test environment renderer_context is not provided
+        renderer_context = renderer_context or {}
         response = renderer_context.get('response', None)
         if response is not None and response.status_code == 204:
             data = None

--- a/apps/annotation/serializers.py
+++ b/apps/annotation/serializers.py
@@ -312,3 +312,12 @@ class UserSerializer(ResourceSerializer):
         pass
 
     attributes = Attributes()
+
+# Annotation request
+
+class AnnotationRequestDeserializer(serializers.Serializer):
+    class Attributes(serializers.Serializer):
+        url = StandardizedRepresentationURLField()
+        quote = serializers.CharField(required=False, allow_blank=True)
+
+    attributes = Attributes()

--- a/apps/annotation/tests/test_mailgun.py
+++ b/apps/annotation/tests/test_mailgun.py
@@ -1,0 +1,48 @@
+import responses
+from django.conf import settings
+from django.test import TestCase
+
+from apps.annotation.mailgun import send_mail, MailSendException
+
+
+class MailgunTest(TestCase):
+
+    @responses.activate
+    def test_request_sent(self):
+        responses.add(responses.Response(
+            method='POST',
+            url=settings.MAILGUN_API_URL,
+            match_querystring=True,
+            content_type='application/json',
+            status=200,
+        ))
+
+        send_mail(
+            to_addr='mock@mail.com',
+            subject='',
+            text='',
+            sender='test',
+        )
+
+        self.assertEqual(len(responses.calls), 1)
+
+
+    @responses.activate
+    def test_exception_raised(self):
+        responses.add(responses.Response(
+            method='POST',
+            url=settings.MAILGUN_API_URL,
+            match_querystring=True,
+            content_type='application/json',
+            status=400,
+        ))
+
+        with self.assertRaises(MailSendException):
+            send_mail(
+                to_addr='mock@mail.com',
+                subject='',
+                text='',
+                sender='test',
+            )
+
+        self.assertEqual(len(responses.calls), 1)

--- a/apps/annotation/tests/views/test_annotation_requests.py
+++ b/apps/annotation/tests/views/test_annotation_requests.py
@@ -1,0 +1,48 @@
+from django.test import TestCase
+from parameterized import parameterized
+from rest_framework.test import APIRequestFactory
+
+from apps.annotation.tests.utils import create_test_user
+from apps.annotation.views.annotation_requests import AnnotationRequests
+
+
+class AnnotationRequestsViewTest(TestCase):
+    maxDiff = None
+
+    # We do not test request URL here and it should not play a role, so we use a fake URL for all requests
+    mock_url = 'mock-url'
+
+    def setUp(self):
+        self.user, password = create_test_user()
+
+    def request_to_class_view(self, view_class, method, data=None, headers=None):
+        factory = APIRequestFactory()
+        # factory.post(...) / .get(...)
+        request = getattr(factory, method)(self.mock_url, data)
+        # mock session since it is expected by some processors
+        request.session = self.client.session
+        headers = headers or {}
+        for key, val in headers.items():
+            request.META[key] = val
+        response = view_class.as_view()(request)
+        return response
+
+    @parameterized.expand([
+        ({'data': {'attributes': {'url': 'http://www.xyz.pl', 'quote': 'fragment tekstu'}}},),
+        ({'data': {'attributes': {'url': 'http://www.xyz.pl'}}},),
+        ({'data': {'attributes': {'url': 'http://www.xyz.pl'}}},),
+    ])
+    def test_post_200(self, data):
+        response = self.request_to_class_view(AnnotationRequests, 'post', data=data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(response)
+
+    @parameterized.expand([
+        ({'data': {'attributes': {'url': 'http://www.xyz.pl'}}}, 'http://www.xyz.pl/'),
+        ({'data': {'attributes': {'url': 'http://www.xyz.pl#xyz'}}}, 'http://www.xyz.pl/'),
+    ])
+    def test_url_standardized(self, data, expected_response_url):
+        response = self.request_to_class_view(AnnotationRequests, 'post', data=data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(response)
+        self.assertEqual(response.data['attributes']['url'], expected_response_url)

--- a/apps/annotation/tests/views/test_annotations.py
+++ b/apps/annotation/tests/views/test_annotations.py
@@ -18,7 +18,7 @@ class AnnotationViewTest(TestCase):
     def setUp(self):
         self.user, password = create_test_user()
 
-    def request_to_class_view(self, view_class, method, data=None, headers=None):
+    def request_to_generic_class_view(self, view_class, method, data=None, headers=None):
         factory = APIRequestFactory()
         # factory.post(...) / .get(...)
         request = getattr(factory, method)(self.mock_url, data)
@@ -32,7 +32,7 @@ class AnnotationViewTest(TestCase):
         return response, results
 
     def test_list_returns_200(self):
-        response, results = self.request_to_class_view(AnnotationList, 'get')
+        response, results = self.request_to_generic_class_view(AnnotationList, 'get')
         self.assertEqual(response.status_code, 200)
         self.assertIsNotNone(results)
 
@@ -40,7 +40,7 @@ class AnnotationViewTest(TestCase):
         mommy.make('annotation.Annotation')
         expected_count = Annotation.objects.count()
 
-        response, results = self.request_to_class_view(AnnotationList, 'get')
+        response, results = self.request_to_generic_class_view(AnnotationList, 'get')
         self.assertEqual(response.status_code, 200)
         self.assertIsNotNone(results)
         self.assertEqual(len(results), expected_count)
@@ -69,7 +69,7 @@ class AnnotationViewTest(TestCase):
         if expected_count == 'all':
             expected_count = Annotation.objects.count()
 
-        response, results = self.request_to_class_view(AnnotationList, 'get', headers={
+        response, results = self.request_to_generic_class_view(AnnotationList, 'get', headers={
             'HTTP_PP_SITE_URL': query_url,
         })
         self.assertEqual(response.status_code, 200)
@@ -85,7 +85,7 @@ class AnnotationViewTest(TestCase):
         if expected_count == 'all':
             expected_count = Annotation.objects.count()
 
-        response, results = self.request_to_class_view(AnnotationList, 'get', data={'url': query_url})
+        response, results = self.request_to_generic_class_view(AnnotationList, 'get', data={'url': query_url})
         self.assertEqual(response.status_code, 200)
         self.assertIsNotNone(results)
         self.assertEqual(len(results), expected_count)
@@ -97,7 +97,7 @@ class AnnotationViewTest(TestCase):
 
         # patch PAGE_SIZE so as not to have to create > 100 Annotations...
         with patch('rest_framework.pagination.LimitOffsetPagination.default_limit', 5):
-            response, results = self.request_to_class_view(AnnotationList, 'get')
+            response, results = self.request_to_generic_class_view(AnnotationList, 'get')
 
         self.assertEqual(response.status_code, 200)
         self.assertIsNotNone(results)

--- a/apps/annotation/urls.py
+++ b/apps/annotation/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import url, include
 
-from apps.annotation.views import users
+from apps.annotation.views import users, annotation_requests
 from .views import annotations, annotation_reports, annotation_upvotes
 
 
@@ -36,6 +36,10 @@ urlpatterns = [
         # Related
         url(r'^/(?P<report_id>[0-9]+)/annotation$', annotations.AnnotationReportRelatedAnnotationSingle.as_view(),
             name='annotation_report_related_annotation'),
+    ])),
+    url(r'^annotationRequests', include([
+        url(r'^$', annotation_requests.AnnotationRequests.as_view(),
+            name='annotation_requests'),
     ])),
     url(r'^users/', include([
         url(r'^(?P<user_id>[0-9]+)$', users.UserSingle.as_view(),

--- a/apps/annotation/views/annotation_requests.py
+++ b/apps/annotation/views/annotation_requests.py
@@ -1,0 +1,39 @@
+from django.conf import settings
+from django.utils.decorators import method_decorator
+from drf_yasg.utils import swagger_auto_schema
+from lazysignup.decorators import allow_lazy_user
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.annotation.mailgun import send_mail
+from apps.annotation.responses import ValidationErrorResponse
+from apps.annotation.serializers import AnnotationRequestDeserializer
+
+
+class AnnotationRequests(APIView):
+
+    @swagger_auto_schema(request_body=AnnotationRequestDeserializer,
+                         responses={200: AnnotationRequestDeserializer})
+    @method_decorator(allow_lazy_user)
+    def post(self, request):
+        deserializer = AnnotationRequestDeserializer(data=request.data)
+        if not deserializer.is_valid():
+            return ValidationErrorResponse(deserializer.errors)
+        data = deserializer.validated_data['attributes']
+
+        subject = 'Prośba o przypis w tekście' if data.get('quote') else 'Prośba o przypis'
+        text = '''
+Użytkownik zgłosił prośbę o przypis!
+URL: {}
+Fragment: {}
+        '''.format(data['url'], data.get('quote'))
+
+        if not (settings.TEST or settings.DEBUG):
+            send_mail(
+                sender='annotation_requests',
+                # TODO should work when the domain is verified
+                to_addr='przypispowszechny@gmail.com',
+                subject=subject,
+                text=text,
+            )
+        return Response(deserializer.data)

--- a/apps/annotation/views/annotation_requests.py
+++ b/apps/annotation/views/annotation_requests.py
@@ -30,8 +30,7 @@ Fragment: {}
 
         if not (settings.TEST or settings.DEBUG):
             send_mail(
-                sender='annotation_requests',
-                # TODO should work when the domain is verified
+                sender='prosba-o-przypis',
                 to_addr='przypispowszechny@gmail.com',
                 subject=subject,
                 text=text,

--- a/apps/annotation/views/annotation_requests.py
+++ b/apps/annotation/views/annotation_requests.py
@@ -5,10 +5,12 @@ from lazysignup.decorators import allow_lazy_user
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.annotation.mailgun import send_mail
+from apps.annotation.mailgun import send_mail, MailSendException
 from apps.annotation.responses import ValidationErrorResponse
 from apps.annotation.serializers import AnnotationRequestDeserializer
 
+import logging
+logger = logging.getLogger('pp.annotation')
 
 class AnnotationRequests(APIView):
 
@@ -28,11 +30,14 @@ URL: {}
 Fragment: {}
         '''.format(data['url'], data.get('quote'))
 
-        if not (settings.TEST or settings.DEBUG):
+        try:
             send_mail(
                 sender='prosba-o-przypis',
                 to_addr='przypispowszechny@gmail.com',
                 subject=subject,
                 text=text,
             )
+        except MailSendException as e:
+            logger.error('Annotation request could not be sent by e-mail: {}'.format(str(e)))
+
         return Response(deserializer.data)

--- a/apps/annotation/views/annotation_requests.py
+++ b/apps/annotation/views/annotation_requests.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.utils.decorators import method_decorator
+from django.utils.text import Truncator
 from drf_yasg.utils import swagger_auto_schema
 from lazysignup.decorators import allow_lazy_user
 from rest_framework.response import Response
@@ -38,6 +39,10 @@ Fragment: {}
                 text=text,
             )
         except MailSendException as e:
-            logger.error('Annotation request could not be sent by e-mail: {}'.format(str(e)))
+            logger.error('Annotation request (url: {}, quote: {}) could not be sent by e-mail: {}'.format(
+                data['url'],
+                Truncator(data.get('quote', '')).chars(20),
+                str(e))
+            )
 
         return Response(deserializer.data)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - ENV_PATH=/opt/env
       - PIP_ROOT=/opt/env/
       - PIP_PREFIX=./
+      - MAILGUN_API_KEY=${MAILGUN_API_KEY} # use local variable in docker env
     entrypoint:
       - ./docker/virtualenv_setup_entrypoint.sh
     # The access-logfile and error-logfile settings to make sure gunicorn does not silence any of them

--- a/settings/base.py
+++ b/settings/base.py
@@ -25,6 +25,7 @@ SECRET_KEY = '_96(y+)c++%-5m6i*4i-4md6o1@zc(5a9fjpoop#%+q=fg3ig9'
 
 DEBUG = False
 
+TEST = False
 # Application definition
 
 INSTALLED_APPS = [
@@ -150,6 +151,10 @@ REST_FRAMEWORK = {
     'DEFAULT_RENDERER_CLASSES': (
         'apps.annotation.renderers.JSONAPIRenderer',
     ),
+    'TEST_REQUEST_RENDERER_CLASSES': (
+        'apps.annotation.renderers.JSONAPIRenderer',
+    ),
+    'TEST_REQUEST_DEFAULT_FORMAT': 'vnd.api+json',
 }
 
 

--- a/settings/dev.py
+++ b/settings/dev.py
@@ -6,3 +6,8 @@ DEBUG = True
 # Chrome extension is allowed access as it explicitly defines allowed resource domains in manifest.json permissions
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_ALLOW_CREDENTIALS = True
+
+# Mailgun settings
+MAILGUN_API_KEY=os.environ.get('MAILGUN_API_KEY')
+PP_MAIL_DOMAIN='dev.mail.przypispowszechny.pl'
+MAILGUN_API_URL='https://api.mailgun.net/v3/{}/messages'.format(PP_MAIL_DOMAIN)

--- a/settings/heroku_dev.py
+++ b/settings/heroku_dev.py
@@ -6,7 +6,7 @@ SECRET_KEY = os.environ.get('PP_SECRET_KEY')
 
 # Mailgun settings
 MAILGUN_API_KEY=os.environ.get('MAILGUN_API_KEY')
-PP_MAIL_DOMAIN='mail.przypispowszechny.pl'
+PP_MAIL_DOMAIN='dev.mail.przypispowszechny.pl'
 MAILGUN_API_URL='https://api.mailgun.net/v3/{}/messages'.format(PP_MAIL_DOMAIN)
 
 ALLOWED_HOSTS = [

--- a/settings/heroku_dev.py
+++ b/settings/heroku_dev.py
@@ -4,6 +4,11 @@ import os
 
 SECRET_KEY = os.environ.get('PP_SECRET_KEY')
 
+# Mailgun settings
+MAILGUN_API_KEY=os.environ.get('MAILGUN_API_KEY')
+PP_MAIL_DOMAIN='mail.przypispowszechny.pl'
+MAILGUN_API_URL='https://api.mailgun.net/v3/{}/messages'.format(PP_MAIL_DOMAIN)
+
 ALLOWED_HOSTS = [
     'devdeploy1.przypispowszechny.pl', 'www.devdeploy1.przypispowszechny.pl',
     'devdeploy2.przypispowszechny.pl', 'www.devdeploy2.przypispowszechny.pl',

--- a/settings/heroku_prod.py
+++ b/settings/heroku_prod.py
@@ -4,6 +4,11 @@ import os
 
 SECRET_KEY = os.environ.get('PP_SECRET_KEY')
 
+# Mailgun settings
+MAILGUN_API_KEY=os.environ.get('MAILGUN_API_KEY')
+PP_MAIL_DOMAIN='mail.przypispowszechny.pl'
+MAILGUN_API_URL='https://api.mailgun.net/v3/{}/messages'.format(PP_MAIL_DOMAIN)
+
 ALLOWED_HOSTS = [
     'przypispowszechny.pl', 'www.przypispowszechny.pl',
 ]

--- a/settings/test.py
+++ b/settings/test.py
@@ -2,6 +2,8 @@ import sys
 
 from settings.base import *
 
+TEST = True
+
 if 'test' in sys.argv:
     DATABASES['default'] = {
         'ENGINE': 'django.db.backends.sqlite3',

--- a/settings/test.py
+++ b/settings/test.py
@@ -14,3 +14,8 @@ if 'test' in sys.argv:
 LOGGING['loggers']['django']['level'] = 'CRITICAL'
 LOGGING['loggers']['pp']['level'] = 'CRITICAL'
 LOGGING['loggers']['pp.publisher']['level'] = 'CRITICAL'
+
+# Mailgun settings
+MAILGUN_API_KEY='mock-mailgun-api-key'
+PP_MAIL_DOMAIN='mail.przypispowszechny.pl'
+MAILGUN_API_URL='https://api.mailgun.net/v3/{}/messages'.format(PP_MAIL_DOMAIN)


### PR DESCRIPTION
Resolves #77 

- currently sending e-mails is disabled for DEBUG and TEST environments.
- two different mail domains for `heroku_dev` and `heroku_prod` so these mails are separated in Mailgun admin panel (logs etc.).

Perhaps a follow-up is needed -- currently the best way to test e-mails is by using `heroku_dev` settings and setting locally necessary variables.